### PR TITLE
Get task

### DIFF
--- a/api/modules/tasks/component.test.js
+++ b/api/modules/tasks/component.test.js
@@ -18,7 +18,7 @@ describe('Tasks API', () => {
     it('should get tasks and return 200 status when called with the appropriate inputs', async () => {
       // Arrange + Act
       const response = await supertest(app)
-        .get('/api/tasks/1/1500/10/0');
+        .get('/api/tasks/?userId=1&range=1500&quantity=10&offset=0');
 
       // Assert
       expect(response.statusCode).toEqual(200);
@@ -43,7 +43,7 @@ describe('Tasks API', () => {
 
       // Act
       const response = await supertest(app)
-        .get('/api/tasks/1/1500/10/0');
+        .get('/api/tasks/?userId=1&range=1500&quantity=10&offset=0');
 
       // Assert
       expect(response.body.requested[0]).toMatchObject(expectedObjectShape);
@@ -54,7 +54,7 @@ describe('Tasks API', () => {
     it('should get return a 404 status wheno tasks are found', async () => {
       // Act + Arrange
       const response = await supertest(app)
-        .get('/api/tasks/999999999992342342/0/10/0');
+        .get('/api/tasks/?userId=930293092239429034890234802&range=1500&quantity=10&offset=0');
       // Assert
       expect(response.statusCode).toEqual(404);
     });

--- a/api/modules/tasks/component.test.js
+++ b/api/modules/tasks/component.test.js
@@ -83,7 +83,7 @@ describe('Tasks API', () => {
 
       // Act
       const response = await supertest(app)
-        .post('/api/tasks/1')
+        .post('/api/tasks/?userId=1')
         .send(body);
       testTaskIdToDelete = response.body.task_id;
 
@@ -108,7 +108,7 @@ describe('Tasks API', () => {
 
       // Act
       const response = await supertest(app)
-        .post('/api/tasks/1')
+        .post('/api/tasks/?userId=1')
         .send(body);
       testTaskIdToDelete = response.body.task_id;
 
@@ -138,7 +138,7 @@ describe('Tasks API', () => {
 
       // Act
       const response = await supertest(app)
-        .post('/api/tasks/1')
+        .post('/api/tasks/?userId=1')
         .send(body);
 
       // Assert

--- a/api/modules/tasks/component.test.js
+++ b/api/modules/tasks/component.test.js
@@ -14,7 +14,7 @@ describe('Tasks API', () => {
     db.end();
   });
 
-  describe('GET tasks/:userId/:range/:quantity/:offset', () => {
+  describe('GET /api/tasks', () => {
     it('should get tasks and return 200 status when called with the appropriate inputs', async () => {
       // Arrange + Act
       const response = await supertest(app)
@@ -60,10 +60,11 @@ describe('Tasks API', () => {
     });
   });
 
-  describe('POST /api/tasks/:userId', () => {
+  describe('POST /api/tasks/', () => {
     it('Should add a task and return 200 status when called with the appropriate parameters', async () => {
       // Arrange
       const body = {
+        userId: 1,
         addressId: undefined,
         streetAddress: '727 N Broadway',
         city: 'Los Angeles',
@@ -94,6 +95,7 @@ describe('Tasks API', () => {
     it('Should add a task and return 200 status when called an addressId instead of an address', async () => {
       // Arrange
       const body = {
+        userId: 1,
         addressId: 1,
         description: 'Can someone watch my dogs for an hour?',
         laborRequired: true,
@@ -120,6 +122,7 @@ describe('Tasks API', () => {
     it('Should throw an API error and return 500 status if locationsService is down', async () => {
       // Arrange
       const body = {
+        userId: 1,
         streetAddress: '727 N Broadway',
         city: 'Los Angeles',
         state: 'CA',
@@ -146,7 +149,7 @@ describe('Tasks API', () => {
     });
   });
 
-  describe('PUT /:taskId', () => {
+  describe('PUT /tasks', () => {
     afterEach(() => jest.restoreAllMocks());
     it('Should update a task and return a 200 status if called with the proper parameters with existing address', async () => {
       // Arrange

--- a/api/modules/tasks/controller.js
+++ b/api/modules/tasks/controller.js
@@ -22,7 +22,7 @@ const taskControllers = {
 
   addTask: async (req, res, next) => {
     const task = {
-      userId: req.params.userId,
+      userId: req.query.userId,
       addressId: req.body.addressId,
       streetAddress: req.body.streetAddress,
       city: req.body.city,

--- a/api/modules/tasks/controller.js
+++ b/api/modules/tasks/controller.js
@@ -22,7 +22,7 @@ const taskControllers = {
 
   addTask: async (req, res, next) => {
     const task = {
-      userId: req.query.userId,
+      userId: req.body.userId,
       addressId: req.body.addressId,
       streetAddress: req.body.streetAddress,
       city: req.body.city,

--- a/api/modules/tasks/controller.js
+++ b/api/modules/tasks/controller.js
@@ -7,10 +7,10 @@ const locationsController = require('../locations/controller');
 const taskControllers = {
   getTasks: async (req, res, next) => {
     const params = {
-      userId: req.params.userId,
-      range: req.params.range,
-      quantity: req.params.quantity,
-      offset: req.params.offset,
+      userId: req.query.userId,
+      range: req.query.range,
+      quantity: req.query.quantity,
+      offset: req.query.offset,
     };
     try {
       const tasks = await tasksService.getTasks(params);

--- a/api/modules/tasks/routes.js
+++ b/api/modules/tasks/routes.js
@@ -6,7 +6,7 @@ const tasksController = require('./controller');
 
 tasks
   .get('/', tasksController.getTasks)
-  .post('/:userId', tasksController.addTask)
+  .post('/', tasksController.addTask)
   .put('/:taskId', tasksController.updateTask)
   .delete('/:taskId', tasksController.deleteTask)
 

--- a/api/modules/tasks/routes.js
+++ b/api/modules/tasks/routes.js
@@ -5,7 +5,7 @@ const tasks = express.Router();
 const tasksController = require('./controller');
 
 tasks
-  .get('/:userId/:range/:quantity/:offset', tasksController.getTasks)
+  .get('/', tasksController.getTasks)
   .post('/:userId', tasksController.addTask)
   .put('/:taskId', tasksController.updateTask)
   .delete('/:taskId', tasksController.deleteTask)

--- a/api/modules/users/component.test.js
+++ b/api/modules/users/component.test.js
@@ -132,12 +132,12 @@ describe('Users API', () => {
     });
   });
 
-  describe('GET api/users/rating/:quantity/:userId/:range', () => {
+  describe('GET api/users/?sortBy&quantity&userId&range', () => {
     afterEach(() => jest.restoreAllMocks());
     it('Gets users array and returns a 200 status when called with appropriate inputs', async () => {
       // Arrange + Act
       const response = await supertest(app)
-        .get('/api/users/rating/10/1/100');
+        .get('/api/users/?sortBy=rating&quantity=10&userId=1&range=100');
 
       // Assert
       expect(response.statusCode).toEqual(200);
@@ -152,7 +152,7 @@ describe('Users API', () => {
     it('throws an API error and returns a 404 when no tasks are found', async () => {
       // Arrange + Act
       const response = await supertest(app)
-        .get('/api/users/rating/0/10/10');
+        .get('/api/users/?sortBy=rating&quantity=10&userId=9921380192839108231&range=100');
 
       // Assert
       expect(response.statusCode).toEqual(404);

--- a/api/modules/users/controller.js
+++ b/api/modules/users/controller.js
@@ -46,14 +46,15 @@ const userController = {
     }
   },
 
-  getUsersByRating: async (req, res, next) => {
+  getUsers: async (req, res, next) => {
     const params = {
-      quantity: req.params.quantity || 25,
-      userId: req.params.userId,
-      range: req.params.range || 1,
+      sortBy: req.query.sortBy || 'ratings',
+      quantity: req.query.quantity || 25,
+      userId: req.query.userId,
+      range: req.query.range || 1,
     };
     try {
-      const users = await usersService.getUsersByRating(params);
+      const users = await usersService.getUsers(params);
       res.status(200).send(users);
     } catch (err) {
       console.log(err);

--- a/api/modules/users/routes.js
+++ b/api/modules/users/routes.js
@@ -6,9 +6,9 @@ const usersController = require('./controller');
 const userValidator = require('./userValidator');
 
 user
+  .get('/', usersController.getUsers)
   .get('/:userId', usersController.getUser)
   .post('/', userValidator.newUser, usersController.addUser)
-  .get('/rating/:quantity/:userId/:range', usersController.getUsersByRating)
   .post('/login', userValidator.checkEmailAndPassword, usersController.authenticateLogin)
   .get('/:userId/session', usersController.authenticateSession);
 

--- a/api/modules/users/service.js
+++ b/api/modules/users/service.js
@@ -96,7 +96,7 @@ const usersService = {
     return userDTO;
   },
 
-  getUsersByRating: async (params) => {
+  getUsers: async (params) => {
     const {
       userId,
       range,

--- a/api/modules/users/unit.test.js
+++ b/api/modules/users/unit.test.js
@@ -302,33 +302,43 @@ describe('Users Controller', () => {
     });
   });
 
-  describe('getUsersByRating', () => {
+  describe('getUsers', () => {
     afterEach(() => jest.restoreAllMocks());
-    it('calls the getUsersByRating service', async () => {
+    it('calls the getUsers service', async () => {
       // Arrange
       const req = getMockReq();
       req.params = { quantity: 10, userId: 1, range: 10 };
-      const getUsersByRatingServiceSpy = jest.spyOn(usersService, 'getUsersByRating').mockImplementation(jest.fn());
+      const getUsersSpy = jest.spyOn(usersService, 'getUsers').mockImplementation(jest.fn());
 
       // Act
-      await usersController.getUsersByRating(req, res, next);
+      await usersController.getUsers(req, res, next);
 
       // Assert
-      expect(getUsersByRatingServiceSpy).toBeCalled();
+      expect(getUsersSpy).toBeCalled();
     });
 
     it('provides default quantity and range parameters if not provided', async () => {
       // Arrange
       const req = getMockReq();
-      req.params = { quantity: undefined, userId: 1, range: undefined };
-      const getUsersByRatingSpy = jest.spyOn(usersService, 'getUsersByRating').mockImplementation(jest.fn());
+      req.query = {
+        sortBy: 'ratings',
+        quantity: undefined,
+        userId: 1,
+        range: undefined,
+      };
+      const getUsersSpy = jest.spyOn(usersService, 'getUsers').mockImplementation(jest.fn());
 
       // Act
-      await usersController.getUsersByRating(req, res, next);
+      await usersController.getUsers(req, res, next);
 
       // Assert
-      expect(getUsersByRatingSpy).toHaveBeenLastCalledWith(
-        expect.objectContaining({ quantity: 25, range: 1, userId: 1 }),
+      expect(getUsersSpy).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          quantity: 25,
+          range: 1,
+          userId: 1,
+          sortBy: 'ratings',
+        }),
       );
     });
   });
@@ -412,7 +422,7 @@ describe('Users Service', () => {
     });
   });
 
-  describe('getUsersByRating', () => {
+  describe('getUsers', () => {
     afterEach(() => jest.restoreAllMocks());
     it('queries the db and returns a users array DTO', async () => {
       // Arrange
@@ -431,7 +441,7 @@ describe('Users Service', () => {
       };
 
       // Act
-      const usersDTO = await usersService.getUsersByRating(params);
+      const usersDTO = await usersService.getUsers(params);
 
       // Assert
       expect(usersDTO[0]).toEqual(userDTO);

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -17,7 +17,7 @@ const App = () => {
   const userId = useSelector((store) => store.currentUserReducer.userData.user_id);
 
   const getTasksByLocation = () => {
-    axios.get(`${url}/api/tasks/${userId}/50/30/0`)
+    axios.get(`${url}/api/tasks/?userId=${userId}&range=50&quantity=30&offset=0`)
       .then(({ data }) => {
         dispatch({ type: 'SET_TASKS', tasks: data.allothers });
         dispatch({ type: 'SET_REQUESTS', myRequests: data.requested });

--- a/client/src/containers/TopHelpers/index.jsx
+++ b/client/src/containers/TopHelpers/index.jsx
@@ -8,11 +8,12 @@ import User from './User';
 
 const TopHelpers = () => {
   const [topReviews, setTopReviews] = useState([{profile_picture_url: ''}, {profile_picture_url: ''}, {profile_picture_url: ''}]);
+  const currentUserId = useSelector((store) => store.currentUserReducer.userData.user_id);
 
   const url = 'http://localhost:3500';
 
   useEffect(() => {
-    axios.get(`${url}/api/users/rating/10`)
+    axios.get(`${url}/api/users/?sortBy=rating&userId=${currentUserId}&quantity=10&range=10`)
       .then(({ data }) => {
         setTopReviews(data);
       })

--- a/client/src/features/Request/RequestModal.jsx
+++ b/client/src/features/Request/RequestModal.jsx
@@ -59,6 +59,7 @@ function NewRequestModal() {
       data.address = data.location;
     }
     setRequest({
+      userId: user.user_id,
       addressId: null,
       streetAddress: data.address.street_address,
       city: data.address.city,
@@ -99,6 +100,8 @@ function NewRequestModal() {
   // resets input values & validation errs when you successfully submit form
   function resetReqAndErr() {
     setRequest({
+      userId: user.user_id,
+      addressId: null,
       streetAddress: '',
       city: '',
       state: '',

--- a/client/src/features/Request/RequestModal.jsx
+++ b/client/src/features/Request/RequestModal.jsx
@@ -157,7 +157,7 @@ function NewRequestModal() {
 
   const postNewRequest = async () => {
     try {
-      const { data } = await axios.post(`${url}/api/tasks/${user.user_id}`, request);
+      const { data } = await axios.post(`${url}/api/tasks/?userId=${user.user_id}`, request);
       console.log(data);
       cleanInputAndClose();
       dispatch({ type: 'SET_TASK', task });


### PR DESCRIPTION
Refactored endpoints to follow RESTFUL naming conventions for query parameters. Prior naming had filtering parameters as resource parameters. moved to query params. tests rewritten accordingly and client endpoints refactored. 